### PR TITLE
Remove hardcoded X display name in XWindowsScreen integration test

### DIFF
--- a/src/test/integtests/platform/XWindowsScreenTests.cpp
+++ b/src/test/integtests/platform/XWindowsScreenTests.cpp
@@ -30,7 +30,7 @@ TEST(CXWindowsScreenTests, fakeMouseMove_nonPrimary_getCursorPosValuesCorrect)
 	EXPECT_CALL(eventQueue, adoptBuffer(_)).Times(2);
 	EXPECT_CALL(eventQueue, removeHandler(_, _)).Times(2);
 	XWindowsScreen screen(
-		":0.0", false, false, 0, &eventQueue);
+		NULL, false, false, 0, &eventQueue);
 
 	screen.fakeMouseMove(10, 20);
 


### PR DESCRIPTION
There is no guarantee the running display will always be :0.0: it isn't
in Fedora 22, for example. Just pass NULL and let the XWindowsScreen
constructor attempt to read the DISPLAY environment variable, and
fallback to :0.0 if needed.
